### PR TITLE
Added multiline handling setting and switched to option functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.0] - 2024-03-07
+
+### Added
+- support for `OptionFunc` to configure the parser
+- way to customize how multiline output is handled.
+  - It can be either preserved, squashed to one line or preserved with indent (e.g. for yaml)
+
+### Changed
+- parser constructor now takes variadic parameter `OptionFunc`
+
+### Removed
+- `maxFunctionCount` parameter from constructor
+
+### Fixed
+- issue where multiline function output would not be indented if it was nested inside of text block.
+
 ## [v1.2.2] - 2024-02-28
 
 ### Changed

--- a/example.parsed.yml
+++ b/example.parsed.yml
@@ -20,6 +20,17 @@ services:
          STRING
         >
 
+      MULTI_LINE_STRING_WITH_MULTI_LINE_FUNCTION: |
+        <ESC
+         APED
+         MULTI L
+         -----BEGIN PUBLIC KEY-----
+         MCOWBQYDK2VWAYEARZCBQVFEAQGU/6OETYA5ARD0Y4ZY8AMB48VMKQ4+RAE=
+         -----END PUBLIC KEY-----
+         INE
+         STRING
+        >
+
       ONE_FUNCTION: "1XHGCl1fcH0hu1W-f-Cn"
       TWO_FUNCTIONS: "-68_yl_iKcO9--KGU0301812"
       NESTED_FUNCTIONS: "A6MrX2352Og0t81SucTivHHRiRATtFibn7BVOAmVOHEfn6xN"

--- a/example.yml
+++ b/example.yml
@@ -20,6 +20,15 @@ services:
          STRING| upper>
         >
 
+      MULTI_LINE_STRING_WITH_MULTI_LINE_FUNCTION: |
+        \<<ESC
+         apEd
+         Multi L
+         <@generateED25519Key(<myED25519Key>)>
+         ine
+         STRING| upper>
+        >
+
       ONE_FUNCTION: "<@generateRandomString(<20>)>"
       TWO_FUNCTIONS: "<@generateRandomString(<20>)><@generateRandomInt(<1>, <9999>)>"
       NESTED_FUNCTIONS: "<@generateRandomString(<@generateRandomInt(<10>, <50>)>)>"

--- a/src/parser/options.go
+++ b/src/parser/options.go
@@ -1,0 +1,26 @@
+package parser
+
+type OptionFunc func(p *Parser)
+
+type MultiLineOutputHandling int
+
+const (
+	// MultilineToOneLine squashes output into a single line with `\n` characters instead of newline
+	MultilineToOneLine MultiLineOutputHandling = iota
+	// MultilinePreserved preservers output with no modifications
+	MultilinePreserved
+	// MultilineWithIndent preserves multiline output, but adds indentation, so all lines are the same (used for yaml)
+	MultilineWithIndent
+)
+
+func WithMultilineOutputHandling(handling MultiLineOutputHandling) OptionFunc {
+	return func(p *Parser) {
+		p.multiLineOutputHandling = handling
+	}
+}
+
+func WithMaxFunctionCount(c int) OptionFunc {
+	return func(p *Parser) {
+		p.maxFunctionCount = c
+	}
+}


### PR DESCRIPTION
## [v2.0.0] - 2024-03-07

### Added
- support for `OptionFunc` to configure the parser
- way to customize how multiline output is handled.
  - It can be either preserved, squashed to one line or preserved with indent (e.g. for yaml)

### Changed
- parser constructor now takes variadic parameter `OptionFunc`

### Removed
- `maxFunctionCount` parameter from constructor

### Fixed
- issue where multiline function output would not be indented if it was nested inside of text block.

Input
```yaml
Something: |
    <Text 
    <@someMultiLineFunction>
    text| upper>
```
Output:
```yaml
Something: |
    TEXT 
    SOME MULTI
LINE FUNCTION
OUTPUT
    TEXT
```